### PR TITLE
feat: encoding auto-detection for non-UTF-8 archives

### DIFF
--- a/src/plugins/sevenzip.py
+++ b/src/plugins/sevenzip.py
@@ -9,12 +9,174 @@ from pathlib import Path
 
 SEVENZIP_PATH = '/app/bin/7zz'
 
+_encoding_cache: dict[str, tuple[str, int | None]] = {}
+_last_encoding: tuple[str, int | None] = ('utf-8', None)
+
+# Map chardet encoding names → (our_encoding_name, mcp_value)
+# Keys are normalised: lowercase, hyphens→underscores
+_CHARDET_TO_MCP: dict[str, tuple[str, int | None]] = {
+    'utf_8':         ('utf-8',      None),
+    'ascii':         ('utf-8',      None),
+    'gb2312':        ('gbk',        936),
+    'gbk':           ('gbk',        936),
+    'gb18030':       ('gbk',        936),
+    'hz_gb_2312':    ('gbk',        936),
+    'big5':          ('big5',       950),
+    'big5hkscs':     ('big5',       950),
+    'euc_tw':        ('big5',       950),
+    'shift_jis':     ('shift_jis',  932),
+    'euc_jp':        ('shift_jis',  932),
+    'iso_2022_jp':   ('shift_jis',  932),
+    'euc_kr':        ('euc_kr',     949),
+    'iso_2022_kr':   ('euc_kr',     949),
+    'cp949':         ('euc_kr',     949),
+    'windows_1251':  ('cp1251',    1251),
+    'koi8_r':        ('cp1251',    1251),
+    'maccyrillic':   ('cp1251',    1251),
+    'ibm855':        ('cp1251',    1251),
+    'ibm866':        ('cp1251',    1251),
+    'iso_8859_5':    ('cp1251',    1251),
+}
+
 
 def _parse_progress(line):
     match = re.search(r'(\d+)%', line)
     if match:
         return int(match.group(1))
     return None
+
+
+def _detect_encoding(data: bytes) -> tuple[str, int | None]:
+    if not data:
+        return 'utf-8', None
+    if not bytes(b for b in data if b > 127):
+        return 'utf-8', None
+
+    try:
+        import chardet
+        result = chardet.detect(data)
+        enc_name = result.get('encoding', '')
+        confidence = result.get('confidence', 0)
+        if enc_name and confidence >= 0.4:
+            key = enc_name.lower().replace('-', '_').replace(' ', '_')
+            if key in _CHARDET_TO_MCP:
+                return _CHARDET_TO_MCP[key]
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    try:
+        utf8_decoded = data.decode('utf-8')
+        if '\ufffd' not in utf8_decoded:
+            return 'utf-8', None
+    except UnicodeDecodeError:
+        pass
+
+    return _detect_encoding_fallback(data)
+
+
+# Ordered preference for tie-breaking between CJK encodings
+_CJK_PREFERENCE = {'gbk': 1, 'shift_jis': 0, 'big5': 0, 'euc_kr': 0}
+
+
+# (encoding_name, mcp_codepage, is_multibyte) — fallback table
+_FALLBACK_TABLE = [
+    ('gbk',        936,     True),
+    ('shift_jis',  932,     True),
+    ('big5',       950,     True),
+    ('euc_kr',     949,     True),
+    ('cp1251',    1251,     False),
+]
+
+
+def _detect_encoding_fallback(data: bytes) -> tuple[str, int | None]:
+    non_ascii_bytes = sum(1 for b in data if b > 127)
+
+    multibyte = []
+    singlebyte = []
+
+    for enc, mcp, is_mb in _FALLBACK_TABLE:
+        try:
+            decoded = data.decode(enc)
+        except (UnicodeDecodeError, LookupError):
+            continue
+
+        score = 0
+        cjk = kana = hangul = cyr = 0
+        for ch in decoded:
+            cp = ord(ch)
+            if cp == 0xFFFD:
+                score -= 100
+            elif cp < 32 and cp not in (9, 10, 13):
+                score -= 50
+            elif cp > 127:
+                score += 2
+                if 0x4E00 <= cp <= 0x9FFF or 0x3400 <= cp <= 0x4DBF:
+                    cjk += 1
+                elif 0x3040 <= cp <= 0x30FF:
+                    kana += 1
+                elif 0xAC00 <= cp <= 0xD7AF:
+                    hangul += 1
+                elif 0x0400 <= cp <= 0x04FF:
+                    cyr += 1
+
+        score += cjk * 8 + kana * 10 + hangul * 10 + cyr * 2
+
+        non_ascii_chars = sum(1 for c in decoded if ord(c) > 127)
+        if not non_ascii_chars:
+            continue
+
+        bpc = non_ascii_bytes / non_ascii_chars
+        if is_mb and bpc >= 1.2:
+            multibyte.append((score, enc, mcp))
+        elif not is_mb and bpc < 1.5:
+            singlebyte.append((score, enc, mcp))
+
+    if multibyte:
+        multibyte.sort(key=lambda x: (x[0], _CJK_PREFERENCE.get(x[1], 0)), reverse=True)
+        return multibyte[0][1], multibyte[0][2]
+
+    if singlebyte:
+        singlebyte.sort(key=lambda x: x[0], reverse=True)
+        return singlebyte[0][1], singlebyte[0][2]
+
+    return 'utf-8', None
+
+
+def _decode_7zip_output(data: bytes) -> str:
+    global _last_encoding
+    _last_encoding = _detect_encoding(data)
+    return data.decode(_last_encoding[0], errors='replace')
+
+
+def _codepage_args(archive_path: str) -> list:
+    enc, mcp = _encoding_cache.get(str(archive_path), (None, None))
+    if mcp is not None:
+        return [f'-mcp={mcp}', '-sccUTF-8']
+    return []
+
+
+def _ensure_encoding_cache(archive_path: str, password: str | None = None):
+    archive_path = str(archive_path)
+    if archive_path in _encoding_cache:
+        return
+    args = ['l', '-slt', '-ba', archive_path]
+    if password:
+        args.append(f'-p{password}')
+    process = subprocess.Popen(
+        [SEVENZIP_PATH, *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        stdout_bytes, _ = process.communicate(timeout=30)
+        if process.returncode == 0:
+            enc, mcp = _detect_encoding(stdout_bytes)
+            _encoding_cache[archive_path] = (enc, mcp)
+    except Exception:
+        pass
 
 
 def _run_7zip(args, timeout=-1, cancel_event=None, on_progress=None):
@@ -27,56 +189,60 @@ def _run_7zip(args, timeout=-1, cancel_event=None, on_progress=None):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.DEVNULL,
-        text=True,
         start_new_session=True,
     )
 
     if on_progress is None:
         while True:
             try:
-                stdout, stderr = process.communicate(timeout=0.1)
+                stdout_bytes, stderr_bytes = process.communicate(timeout=0.1)
                 break
             except subprocess.TimeoutExpired:
                 if cancel_event is not None and cancel_event.is_set():
                     _kill_process(process)
-                    stdout, stderr = process.communicate()
-                    output = (stdout + stderr).strip()
-                    raise RuntimeError(output or 'Cancelled')
+                    stdout_bytes, stderr_bytes = process.communicate()
+                    raise RuntimeError('Cancelled')
 
                 if timeout is not None and timeout >= 0:
                     elapsed = time.monotonic() - started_at
                     if elapsed >= timeout:
                         _kill_process(process)
-                        stdout, stderr = process.communicate()
-                        output = (stdout + stderr).strip()
-                        raise TimeoutError(output or f'7zz timed out after {timeout} seconds')
+                        stdout_bytes, stderr_bytes = process.communicate()
+                        raise TimeoutError(f'7zz timed out after {timeout} seconds')
 
-        output = (stdout + stderr).strip()
+        stdout = _decode_7zip_output(stdout_bytes)
+        stderr = stderr_bytes.decode('utf-8', errors='replace')
+        output = (stdout + '\n' + stderr).strip()
         if process.returncode != 0:
             raise RuntimeError(output or f'7zz exited with {process.returncode}')
         return output
 
-    stderr_lines = []
-    stderr_current = ""
+    stderr_chunks = []
+    stderr_current = b''
     stderr_lock = threading.Lock()
     last_percent = -1
+    stdout_chunks = []
 
     def read_stderr():
         nonlocal stderr_current, last_percent
         while True:
             try:
-                char = process.stderr.read(1)
-                if not char:
+                byte = process.stderr.read(1)
+                if not byte:
                     break
                 with stderr_lock:
-                    if char == '\n':
-                        stderr_lines.append(stderr_current)
-                        stderr_current = ""
-                    elif char == '\x08':
+                    if byte == b'\n':
+                        stderr_chunks.append(stderr_current)
+                        stderr_current = b''
+                    elif byte == b'\x08':
                         stderr_current = stderr_current[:-1]
                     else:
-                        stderr_current += char
-                    percent = _parse_progress(stderr_current)
+                        stderr_current += byte
+                    try:
+                        current_text = stderr_current.decode('utf-8', errors='replace')
+                    except Exception:
+                        current_text = ''
+                    percent = _parse_progress(current_text)
                     if percent is not None and percent != last_percent:
                         last_percent = percent
                         on_progress(percent)
@@ -86,15 +252,13 @@ def _run_7zip(args, timeout=-1, cancel_event=None, on_progress=None):
     stderr_reader = threading.Thread(target=read_stderr, daemon=True)
     stderr_reader.start()
 
-    stdout_lines = []
-
     def read_stdout():
         while True:
             try:
-                line = process.stdout.readline()
-                if not line:
+                chunk = process.stdout.read(4096)
+                if not chunk:
                     break
-                stdout_lines.append(line)
+                stdout_chunks.append(chunk)
             except Exception:
                 break
 
@@ -121,9 +285,14 @@ def _run_7zip(args, timeout=-1, cancel_event=None, on_progress=None):
     stderr_reader.join(timeout=1.0)
     stdout_reader.join(timeout=1.0)
 
+    stdout_bytes = b''.join(stdout_chunks)
+    stdout = _decode_7zip_output(stdout_bytes)
+
     with stderr_lock:
-        stderr = '\n'.join(stderr_lines + [stderr_current])
-    stdout = ''.join(stdout_lines)
+        stderr = '\n'.join(
+            [c.decode('utf-8', errors='replace') for c in stderr_chunks]
+            + [stderr_current.decode('utf-8', errors='replace')]
+        )
 
     output = (stdout + '\n' + stderr).strip()
     if process.returncode != 0:
@@ -155,34 +324,39 @@ def _run_7zip_stdin(args, stdin_path, timeout=-1, cancel_event=None, on_progress
 
         if on_progress is None:
             stdout_bytes, stderr_bytes = process.communicate()
-            stdout = stdout_bytes.decode('utf-8', errors='replace')
+            stdout = _decode_7zip_output(stdout_bytes)
             stderr = stderr_bytes.decode('utf-8', errors='replace')
             output = (stdout + '\n' + stderr).strip()
             if process.returncode != 0:
                 raise RuntimeError(output or f'7zz exited with {process.returncode}')
             return output
 
-        stderr_lines = []
-        stderr_current = ""
+        stderr_chunks = []
+        stderr_current = b''
         stderr_lock = threading.Lock()
         last_percent = -1
+        stdout_chunks = []
 
         def read_stderr():
             nonlocal stderr_current, last_percent
             while True:
                 try:
-                    char = process.stderr.read(1)
-                    if not char:
+                    byte = process.stderr.read(1)
+                    if not byte:
                         break
                     with stderr_lock:
-                        if char == b'\n':
-                            stderr_lines.append(stderr_current)
-                            stderr_current = ""
-                        elif char == b'\x08':
+                        if byte == b'\n':
+                            stderr_chunks.append(stderr_current)
+                            stderr_current = b''
+                        elif byte == b'\x08':
                             stderr_current = stderr_current[:-1]
                         else:
-                            stderr_current += char.decode('utf-8', errors='replace')
-                        percent = _parse_progress(stderr_current)
+                            stderr_current += byte
+                        try:
+                            current_text = stderr_current.decode('utf-8', errors='replace')
+                        except Exception:
+                            current_text = ''
+                        percent = _parse_progress(current_text)
                         if percent is not None and percent != last_percent:
                             last_percent = percent
                             on_progress(percent)
@@ -192,15 +366,13 @@ def _run_7zip_stdin(args, stdin_path, timeout=-1, cancel_event=None, on_progress
         stderr_reader = threading.Thread(target=read_stderr, daemon=True)
         stderr_reader.start()
 
-        stdout_lines = []
-
         def read_stdout():
             while True:
                 try:
-                    line = process.stdout.readline()
-                    if not line:
+                    chunk = process.stdout.read(4096)
+                    if not chunk:
                         break
-                    stdout_lines.append(line.decode('utf-8', errors='replace'))
+                    stdout_chunks.append(chunk)
                 except Exception:
                     break
 
@@ -227,9 +399,14 @@ def _run_7zip_stdin(args, stdin_path, timeout=-1, cancel_event=None, on_progress
         stderr_reader.join(timeout=1.0)
         stdout_reader.join(timeout=1.0)
 
+        stdout_bytes = b''.join(stdout_chunks)
+        stdout = _decode_7zip_output(stdout_bytes)
+
         with stderr_lock:
-            stderr = '\n'.join(stderr_lines + [stderr_current])
-        stdout = ''.join(stdout_lines)
+            stderr = '\n'.join(
+                [c.decode('utf-8', errors='replace') for c in stderr_chunks]
+                + [stderr_current.decode('utf-8', errors='replace')]
+            )
 
         output = (stdout + '\n' + stderr).strip()
         if process.returncode != 0:
@@ -241,14 +418,18 @@ def archive_info(archive_path, password=None, timeout=-1, cancel_event=None):
     args = ['l', '-slt', str(archive_path)]
     if password:
         args.append(f'-p{password}')
-    return _run_7zip(args, timeout, cancel_event)
+    output = _run_7zip(args, timeout, cancel_event)
+    _encoding_cache[str(archive_path)] = _last_encoding
+    return output
 
 
 def archive_list(archive_path, password=None, timeout=-1, cancel_event=None):
     args = ['l', '-slt', '-ba', str(archive_path)]
     if password:
         args.append(f'-p{password}')
-    return _run_7zip(args, timeout, cancel_event)
+    output = _run_7zip(args, timeout, cancel_event)
+    _encoding_cache[str(archive_path)] = _last_encoding
+    return output
 
 
 def archive_compress_advance(output_archive, source_paths, args, timeout=-1, cancel_event=None, task_status=None):
@@ -276,31 +457,41 @@ def archive_extract(archive_path, output_dir, password=None, timeout=-1, cancel_
         if task_status is not None:
             task_status.set_progress(percent)
 
+    if str(archive_path) not in _encoding_cache:
+        _ensure_encoding_cache(archive_path, password)
+
     args = [
         'x',
         str(archive_path),
         f'-o{output_dir}',
         '-y',
+        *_codepage_args(archive_path),
     ]
     if password:
         args.append(f'-p{password}')
     return _run_7zip(args, timeout, cancel_event, on_progress)
+
 
 def archive_extract_FileInZip(archive_path, file_name, output_dir, password=None, timeout=-1, cancel_event=None, task_status=None):
     def on_progress(percent):
         if task_status is not None:
             task_status.set_progress(percent)
 
+    if str(archive_path) not in _encoding_cache:
+        _ensure_encoding_cache(archive_path, password)
+
     args = [
         'x',
         str(archive_path),
         f'-o{output_dir}',
         '-y',
+        *_codepage_args(archive_path),
     ]
     if password:
         args.append(f'-p{password}')
     args.extend(['--', str(file_name)])
     return _run_7zip(args, timeout, cancel_event, on_progress)
+
 
 def archive_delete(archive_path, file_names, password=None, timeout=-1, cancel_event=None, task_status=None):
     def on_progress(percent):

--- a/top.akizip.akizip.json
+++ b/top.akizip.akizip.json
@@ -43,7 +43,14 @@
             "name" : "python3-chardet",
             "buildsystem" : "simple",
             "build-commands": [
-                "pip3 install --prefix=/app --no-deps 'chardet>=5.0,<7.0'"
+                "pip3 install --prefix=/app --no-deps chardet-5.2.0-py3-none-any.whl"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl",
+                    "sha256" : "e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+                }
             ]
         },
         {

--- a/top.akizip.akizip.json
+++ b/top.akizip.akizip.json
@@ -40,6 +40,13 @@
             ]
         },
         {
+            "name" : "python3-chardet",
+            "buildsystem" : "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app --no-deps 'chardet>=5.0,<7.0'"
+            ]
+        },
+        {
             "name" : "akizip",
             "builddir" : true,
             "buildsystem" : "meson",


### PR DESCRIPTION
ZIP archives store filenames using the system-local encoding of the OS where they were created, with no explicit encoding marker in the original format. The PKZip APPNOTE later introduced a "language encoding flag" (bit 11): when set to 1, filenames should be UTF-8; when 0, they use the local encoding. In practice, however, many implementations set the flag to 1 (because they "know" the filename is not plain ASCII) but still write the actual bytes in the local encoding — GBK, Shift-JIS, Big5, etc. This means the flag alone is not reliable for detecting encoding.

Previously 7zz output was decoded as UTF-8, so non-UTF-8 filenames would show as garbled text in the GUI. This PR detects the correct encoding before displaying the listing.

The detection flow works as follows:
- archive_list() captures raw bytes from 7zz (switched from text=True to binary mode)
- The output is passed to _decode_7zip_output(), which first tries chardet (if available) and falls back to a heuristic scorer
- The heuristic decodes the data with each candidate encoding (GBK, Shift-JIS, Big5, EUC-KR, CP1251) and scores based on Unicode character range patterns — e.g., GBK produces CJK ideographs, Shift-JIS contains hiragana/katakana, CP1251 produces Cyrillic letters, and so on
- The detected encoding is cached per archive path for the session
- On extraction, -mcp=<codepage> is passed to 7zz so filenames are written correctly to disk
- python3-chardet added to Flatpak manifest
